### PR TITLE
Optimize ordinary text parsing

### DIFF
--- a/src/BlockType.elm
+++ b/src/BlockType.elm
@@ -9,6 +9,7 @@ module BlockType exposing
     , isMarkDown
     , isOListItem
     , level
+    , parse
     , prefixOfBlockType
     , stringOfBlockType
     )

--- a/tests/LineTypeTests.elm
+++ b/tests/LineTypeTests.elm
@@ -1,64 +1,49 @@
-module LineTypeTests exposing (..)
+module LineTypeTests exposing (lineTypeTests)
 
+import BlockType exposing (..)
 import Expect exposing (Expectation)
 import Fuzz exposing (Fuzzer, int, list, string)
+import Option
+import Parser.Advanced exposing (run)
 import Test exposing (..)
-import BlockType exposing(..)
-import Parser.Advanced exposing(run)
 
-suite : Test
-suite =
-    describe "The MMParser module"
-        [ lineTypeTests
 
-        ]
-
+parse =
+    BlockType.parse Option.ExtendedMath
 
 
 lineTypeTests =
     describe "BlockType.parse"
         [ test "code block" <|
-                \_ ->
-                 "```foo" |> run parse |>  Expect.equal (Ok (BalancedBlock DisplayCode))
-
-          , test "verbatim block" <|
-                \_ ->
-                 "````foo" |> run parse |>  Expect.equal (Ok (BalancedBlock Verbatim))
-
-          , test "display math block" <|
-                  \_ ->
-                       "$$\n" |> run parse |>  Expect.equal (Ok (BalancedBlock DisplayMath))
-
-         , test "image block" <|
-                  \_ ->
-                       "![yada]" |> run parse |>  Expect.equal (Ok (MarkdownBlock Image))
-
+            \_ ->
+                "```foo" |> run parse |> Expect.equal (Ok (BalancedBlock DisplayCode))
+        , test "verbatim block" <|
+            \_ ->
+                "````foo" |> run parse |> Expect.equal (Ok (BalancedBlock Verbatim))
+        , test "display math block" <|
+            \_ ->
+                "$$\n" |> run parse |> Expect.equal (Ok (BalancedBlock DisplayMath))
+        , test "image block" <|
+            \_ ->
+                "![yada]" |> run parse |> Expect.equal (Ok (MarkdownBlock Image))
         , test "unordered list item" <|
-                  \_ ->
-                       "- One" |> run parse |>  Expect.equal (Ok (MarkdownBlock UListItem))
-
+            \_ ->
+                "- One" |> run parse |> Expect.equal (Ok (MarkdownBlock UListItem))
         , test "ordered list item" <|
-                          \_ ->
-                               "2. foo" |> run parse |>  Expect.equal (Ok (MarkdownBlock OListItem))
-
+            \_ ->
+                "2. foo" |> run parse |> Expect.equal (Ok (MarkdownBlock (OListItem 0)))
         , test "quotation" <|
-                          \_ ->
-                               "> foo" |> run parse |>  Expect.equal (Ok (MarkdownBlock Quotation))
-
+            \_ ->
+                "> foo" |> run parse |> Expect.equal (Ok (MarkdownBlock Quotation))
         , test "poetry" <|
-                          \_ -> ">> Twas the night ..." |> run parse |>  Expect.equal (Ok (MarkdownBlock Poetry))
-
+            \_ -> ">> Twas the night ..." |> run parse |> Expect.equal (Ok (MarkdownBlock Poetry))
         , test "Heading level 1" <|
-                          \_ ->
-                               "# Introduction" |> run parse |>  Expect.equal (Ok (MarkdownBlock (Heading 1)))
-
-       , test "Heading level 2" <|
-                          \_ ->
-                               "## Insects" |> run parse |>  Expect.equal (Ok (MarkdownBlock (Heading 2)))
-
-      , test "Thematic break" <|
-                          \_ ->
-                               "___" |> run parse |>  Expect.equal (Ok (MarkdownBlock HorizontalRule))
-
-
+            \_ ->
+                "# Introduction" |> run parse |> Expect.equal (Ok (MarkdownBlock (Heading 1)))
+        , test "Heading level 2" <|
+            \_ ->
+                "## Insects" |> run parse |> Expect.equal (Ok (MarkdownBlock (Heading 2)))
+        , test "Thematic break" <|
+            \_ ->
+                "___" |> run parse |> Expect.equal (Ok (MarkdownBlock HorizontalRule))
         ]

--- a/tests/MMInlineTests.elm
+++ b/tests/MMInlineTests.elm
@@ -1,0 +1,109 @@
+module MMInlineTests exposing (ordinaryTextParsing)
+
+import Expect exposing (Expectation)
+import MMInline
+import Parser.Advanced exposing (run)
+import Test exposing (..)
+
+
+{-| The behavior of the ordinary text parser is slightly different between the three modes
+
+  - Standard: ordinary text cannot begin with '\`', '[', '\*' or '\\n'.
+  - Extended: additionally, ordinary text cannot begin with `~`.
+  - ExtendedMath: additionally, ordinary text cannot begin with `~` or '$'.
+
+Ordinary text can start with a ']', but a ']' at a later point terminates the ordinary text block parser.
+
+-}
+ordinaryTextParsing : Test
+ordinaryTextParsing =
+    let
+        error =
+            Err
+                [ { col = 1
+                  , contextStack = []
+                  , problem = MMInline.Expecting "expecting regular character to begin ordinary text line"
+                  , row = 1
+                  }
+                ]
+
+        generalOrdinaryTextTests parser =
+            describe "behavior that is the same for all three modes"
+                [ test "leading backtick (`)" <|
+                    \_ ->
+                        "`hahaha"
+                            |> run MMInline.ordinaryTextStandard
+                            |> Expect.equal error
+                , test "leading opening square bracket ([)" <|
+                    \_ ->
+                        "[hahaha"
+                            |> run MMInline.ordinaryTextStandard
+                            |> Expect.equal error
+                , test "leading asterisk (*)" <|
+                    \_ ->
+                        "*hahaha"
+                            |> run MMInline.ordinaryTextStandard
+                            |> Expect.equal error
+                , test "leading newline (\n)" <|
+                    \_ ->
+                        "\nhahaha"
+                            |> run MMInline.ordinaryTextStandard
+                            |> Expect.equal error
+                , test "leading closing square bracket (])" <|
+                    \_ ->
+                        "]hahaha"
+                            |> run MMInline.ordinaryTextStandard
+                            |> Expect.equal (Ok (MMInline.OrdinaryText "]hahaha"))
+                , test "closing square bracket terminates normal text" <|
+                    \_ ->
+                        "haha]ha"
+                            |> run MMInline.ordinaryTextStandard
+                            |> Expect.equal (Ok (MMInline.OrdinaryText "haha"))
+                , test "normal text" <|
+                    \_ ->
+                        "hahaha"
+                            |> run MMInline.ordinaryTextStandard
+                            |> Expect.equal (Ok (MMInline.OrdinaryText "hahaha"))
+                ]
+    in
+    describe "The MMInline module"
+        [ describe "Standard"
+            [ test "leading dollar ($)" <|
+                \_ ->
+                    "$hahaha"
+                        |> run MMInline.ordinaryTextStandard
+                        |> Expect.equal (Ok (MMInline.OrdinaryText "$hahaha"))
+            , test "leading tilde (~)" <|
+                \_ ->
+                    "~hahaha"
+                        |> run MMInline.ordinaryTextStandard
+                        |> Expect.equal (Ok (MMInline.OrdinaryText "~hahaha"))
+            , generalOrdinaryTextTests MMInline.ordinaryTextStandard
+            ]
+        , describe "Extended"
+            [ test "leading dollar ($)" <|
+                \_ ->
+                    "$hahaha"
+                        |> run MMInline.ordinaryTextExtended
+                        |> Expect.equal (Ok (MMInline.OrdinaryText "$hahaha"))
+            , test "leading tilde (~)" <|
+                \_ ->
+                    "~hahaha"
+                        |> run MMInline.ordinaryTextExtended
+                        |> Expect.equal error
+            , generalOrdinaryTextTests MMInline.ordinaryTextExtended
+            ]
+        , describe "ExtendedMath"
+            [ test "leading dollar ($)" <|
+                \_ ->
+                    "$hahaha"
+                        |> run MMInline.ordinaryTextExtendedMath
+                        |> Expect.equal error
+            , test "leading tilde (~)" <|
+                \_ ->
+                    "~hahaha"
+                        |> run MMInline.ordinaryTextExtendedMath
+                        |> Expect.equal error
+            , generalOrdinaryTextTests MMInline.ordinaryTextExtendedMath
+            ]
+        ]


### PR DESCRIPTION
This PR gives an order of magnitude speedup for regular text.

Previously, the parser would for every ordinary character:

- spawn a list of special characters (allocation is costly)
- perform  with the current character on that list (has O(n) time complexity)

Because this is ran for most characters, this was a bottleneck. 

In the general case, it is much better to 

- Use `Set.member`
- define your options in the global scope: then they are allocated once and reused for every call of the function, instead of reallocated for each call.

But in this case, writing out an explicit function that checks for all the cases even more efficient. In my benchmark, performance for a couple paragraphs went from ~170 runs/s to ~7000 runs/s

I also made the test suite run again, and added some tests for the ordinary text parser. Can you confirm that the behavior for `]` is correct? it seems weird that it terminates a text block. 