### PR TITLE
Make non-highlighted rendering use existing background

### DIFF
--- a/src/Markdown/Render.elm
+++ b/src/Markdown/Render.elm
@@ -367,7 +367,7 @@ selectedStyle_ targetId currentId =
         HA.style "background-color" highlightColor
 
     else
-        HA.style "background-color" "#fff"
+        HA.style "background-color" "transparent"
 
 
 {-| DOC sync: if targetId == currentId, then return highlighted style
@@ -380,7 +380,7 @@ selectedStyle targetId currentId =
         [ HA.style "background-color" highlightColor, HA.style "line-height" "1.5", HA.style "white-space" "normal" ]
 
     else
-        [ HA.style "background-color" "#fff", HA.style "line-height" "1.5", HA.style "white-space" "normal" ]
+        [ HA.style "background-color" "transparent", HA.style "line-height" "1.5", HA.style "white-space" "normal" ]
 
 
 mmBlockTreeToHtml : Id -> Tree MDBlockWithId -> Html MarkdownMsg


### PR DESCRIPTION
`Markdown.Render` sets the background of some elements to `#fff`. This can clash with the style into which the markdown is rendered, and is very apparent in "dark mode" styles. This PR changes the non-highlighted `background-color` from solid white to `transparent` so that those elements adopt the parent background colour.